### PR TITLE
remove deasync dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "chalk": "1.0.0",
-    "deasync": "0.1.0",
     "inquirer": "0.8.5",
     "selfish": "1.0.2",
     "shelljs": "0.5.1",


### PR DESCRIPTION
I struggled in installing jhypster uml in linux/windows . It seems to be related to deasync dependency .
I removed it from package.json . All test passed  and generated uml with success . 
I think deasync  dependency is unessary unless i miss something . if it is not the case this pull request removes it from package . (sorry for the typos )