### PR TITLE
Fixing multiple relationship on same entities

### DIFF
--- a/lib/dsl/dsl_parser.js
+++ b/lib/dsl/dsl_parser.js
@@ -52,7 +52,9 @@ DSLParser.prototype.fillAssociations = function() {
   for (var i = 0; i < relationships.length; i++){
     var relationship = this.changeMtOtoOtM(relationships[i]); //we change a many-to-one to a one-to-many
 
-    var associationsID = relationship.from.name+'_to_'+relationship.to.name;
+    var associationsID = relationship.from.name + '_' + relationship.from.injectedfield
+                       + '_to_'
+                       + relationship.to.name + '_' + relationship.to.injectedfield;
 
     this.checkEntityDeclaration(relationship, associationsID);
 


### PR DESCRIPTION
When having multiple relationships over the same entity, the generated code is incorrect by using the same **relationshipName** and **relationshipFieldName** on the **relationshipOtherSide**.

For example
```
entity Person { }
entity Task { }
relationship OneToMany {
  Person{owningTask} to Task{owner}
}
relationship OneToMany {
  Person{assignedTask} to Task{assignee}
}
```