### PR TITLE
Fixing multiple relationship on same entities

### DIFF
--- a/lib/dsl/dsl_parser.js
+++ b/lib/dsl/dsl_parser.js
@@ -52,7 +52,9 @@ DSLParser.prototype.fillAssociations = function() {
   for (var i = 0; i < relationships.length; i++){
     var relationship = this.changeMtOtoOtM(relationships[i]); //we change a many-to-one to a one-to-many
 
-    var associationsID = relationship.from.name+'_to_'+relationship.to.name;
+    var associationsID = relationship.from.name + '_' + relationship.from.injectedfield
+                       + '_to_'
+                       + relationship.to.name + '_' + relationship.to.injectedfield;
 
     this.checkEntityDeclaration(relationship, associationsID);
 

--- a/test/dsl_parser_test.js
+++ b/test/dsl_parser_test.js
@@ -106,13 +106,13 @@ describe("DSL Parser", function(){
         expect(Object.keys(parser.parsedData.associations).length).to.be.equal(7);
       });
       it("the associations Object is well formed",function(){
-        expect(parser.parsedData.getAssociation("Departement_to_Employee").name).to.be.equal("departement");
-        expect(parser.parsedData.getAssociation("Departement_to_Employee").type).to.be.equal("Departement");
+        expect(parser.parsedData.getAssociation("Departement_employee_to_Employee_departement").name).to.be.equal("departement");
+        expect(parser.parsedData.getAssociation("Departement_employee_to_Employee_departement").type).to.be.equal("Departement");
       });
       it("the injectedFields Object is well formed",function(){
         expect(parser.parsedData.getInjectedField("Departement_employee").name).to.be.equal("employee");
         expect(parser.parsedData.getInjectedField("Departement_employee").type).to.be.equal("Employee");
-        expect(parser.parsedData.getInjectedField("Departement_employee").association).to.be.equal("Departement_to_Employee");
+        expect(parser.parsedData.getInjectedField("Departement_employee").association).to.be.equal("Departement_employee_to_Employee_departement");
         expect(parser.parsedData.getInjectedField("Departement_employee").class).to.be.equal("Departement");
         expect(parser.parsedData.getInjectedField("Departement_employee").cardinality).to.be.equal("one-to-many");
       });


### PR DESCRIPTION
When having multiple relationships over the same entity, the generated code is incorrect by using the same **relationshipName** and **relationshipFieldName** on the **relationshipOtherSide**.

For example
```
entity Person { }
entity Task { }
relationship OneToMany {
  Person{owningTask} to Task{owner}
}
relationship OneToMany {
  Person{assignedTask} to Task{assignee}
}
```