### PR TITLE
entitiesToSuppress fix / enum key value support 

### DIFF
--- a/lib/editors/modelio_parser.js
+++ b/lib/editors/modelio_parser.js
@@ -91,7 +91,15 @@ ModelioParser.prototype.fillEnums = function () {
               exceptions.NullPointer,
               "The Enumeration's values can't be null.");
         }
-        enumData.values.push(literalIndex.$.name.toUpperCase());
+        // in case enum has a value (supports currently only one) [e.g. USER_NAME("User Name"), JANUARY(0) ]
+        if(literalIndex.$.name.indexOf("(") != -1 ){
+          enumData.values.push(literalIndex.$.name.replace(/(.*)\(([^\)]*)\)/, function(match, p1, p2) { 
+            return p1.toUpperCase().replace(/\s/g,"_") + "("+ p2.replace(/&quot;|'/g,'"') +")";
+          }));
+        } else {
+          // replace space with _ 
+          enumData.values.push(literalIndex.$.name.toUpperCase().replace(/\s/g,"_"));
+        }
       });
     }
     this.parsedData.addEnum(enumElement.$['xmi:id'], enumData);

--- a/lib/entitiescreator.js
+++ b/lib/entitiescreator.js
@@ -184,12 +184,12 @@ function fillEntities() {
               ' it will be kept but all attributes and relationships from it' +
               ' will be disregarded.'));
       entitiesToSuppress.push(classId);
-    }
+    }   
     setFieldsOfEntity(classId);
-    setRelationshipOfEntity(classId);
+    setRelationshipOfEntity(classId);  
   }
   for (let entity in entitiesToSuppress) {
-    delete entities[entity];
+    delete entities[entitiesToSuppress[entity]];
   }
 }
 

--- a/lib/jhipsteruml.js
+++ b/lib/jhipsteruml.js
@@ -23,6 +23,7 @@ const fs = require('fs'),
     readJSONFiles = require('./utils/jhipster_utils').readJSONFiles,
     areJHipsterEntitiesEqual = require('./helpers/object_helper').areJHipsterEntitiesEqual,
     values = require('./utils/object_utils').values,
+    keys = require('./utils/object_utils').keys,
     exportToJSON = require('./export/json_exporter').exportToJSON;
 
 var options = parseOptions(process.argv);
@@ -36,12 +37,14 @@ if (options.displayVersion) {
   process.exit(0);
 }
 
-if (!fs.statSync('./.yo-rc.json').isFile()) {
-  console.info(
+fs.exists('./.yo-rc.json', function (exists) {
+  if (!exists) {
+    console.info(
       chalk.yellow(
-          'Warning: you are using JHipster UML outside a JHipster project and '
-          + 'some files might not be correctly generated.'));
-}
+        '\nWarning: you are using JHipster UML outside a JHipster project and '
+        + 'some files might not be correctly generated.'));
+  }
+});
 
 try {
   fs.statSync('.juml').isFile();
@@ -86,10 +89,10 @@ var entities = createEntities({
 });
 
 var entityIdsByName = {};
-for (let i = 0, entityIds = Object.keys(parsedData.classes); i < parsedData.classNames.length; i++) {
-  entityIdsByName[parsedData.getClass(entityIds[i]).name] = entityIds[i];
+for (let entityId in entities) { // only 
+    entityIdsByName[parsedData.getClass(entityId).name] = entityId;
 }
-var entityNamesToGenerate = filterOutUnchangedEntities(entities, parsedData); // todo change it, or the next called functions?
+var entityNamesToGenerate = filterOutUnchangedEntities(entities, { classNames : keys(entityIdsByName)}); // instead of 'parsedData'
 
 exportToJSON(entities, values(entityIdsByName), parsedData);
 generateEntities(values(entityIdsByName), parsedData.classes, options.force,

--- a/lib/utils/object_utils.js
+++ b/lib/utils/object_utils.js
@@ -5,7 +5,8 @@ const buildException = require('../exceptions/exception_factory').buildException
 
 module.exports = {
   merge: merge,
-  values: values
+  values: values,
+  keys: keys
 };
 
 /**
@@ -42,4 +43,17 @@ function values(object) {
     values.push(object[keys[i]]);
   }
   return values;
+}
+
+function keys(object) {
+  if (object == null) {
+    throw new buildException(exceptions.NullPointer, 'The passed object must not be nil.');
+  }
+  var result = [], key;
+  for (key in object) {
+    if (object.hasOwnProperty(key)) {
+      result.push(key);
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
Fixes: 
- entitiesToSuppress  in lib/entitiescreator.js  and entityNamesToGenerate in lib/jhipsteruml.js
- file exists (.yo-rc.json)

Changes proposed in this Pull Request:
  - support enum values (modelio parser)



