### PR TITLE
fix memberEnd order in association for umlDesigner

### DIFF
--- a/lib/editors/umldesigner_parser.js
+++ b/lib/editors/umldesigner_parser.js
@@ -228,39 +228,51 @@ function fillAssociations() {
 }
 
 function addAssociation(associationElement) {
-  var associationData = getAssociationEnds(associationElement);
-  associationData.type = getAssociationType(associationElement);
+  var idxs = getAssociationOwnedEndsOrder(associationElement);
+  var associationData = getAssociationEnds(associationElement, idxs);
+  associationData.type = getAssociationType(associationElement, idxs);
   var comments = getAssociationComments(associationElement);
   associationData.commentInFrom = comments.commentInFrom;
   associationData.commentInTo = comments.commentInTo;
   parsedData.addAssociation(associationElement.$['xmi:id'], associationData);
 }
 
-function getAssociationEnds(association) {
+function getAssociationOwnedEndsOrder(association) {
+  if(association.$.memberEnd)
+  {
+    var ids = _.split(association.$.memberEnd, ' ');
+    // manage reverse order
+    if(ids[0] == association.ownedEnd[1].$['xmi:id'] && ids[1] == association.ownedEnd[0].$['xmi:id'])
+      return { from: 1, to: 0}
+  }
+  return { from: 0, to: 1};
+}
+
+function getAssociationEnds(association, idxs) {
   var data = {
-    from: association.ownedEnd[0].$.type,
-    to: association.ownedEnd[1].$.type,
-    injectedFieldInFrom: association.ownedEnd[1].$.name,
-    injectedFieldInTo: association.ownedEnd[0].$.name
+    from: association.ownedEnd[idxs.from].$.type,
+    to: association.ownedEnd[idxs.to].$.type,
+    injectedFieldInFrom: association.ownedEnd[idxs.to].$.name,
+    injectedFieldInTo: association.ownedEnd[idxs.from].$.name
   };
-  if (association.ownedEnd[0].lowerValue[0].$.value !== '0' && association.ownedEnd[0].lowerValue[0].$.value !== undefined) {
+  if (association.ownedEnd[idxs.from].lowerValue[0].$.value !== '0' && association.ownedEnd[idxs.from].lowerValue[0].$.value !== undefined) {
     data.isInjectedFieldInFromRequired = true;
   }
-  if (association.ownedEnd[1].lowerValue[0].$.value !== '0' && association.ownedEnd[1].lowerValue[0].$.value !== undefined) {
+  if (association.ownedEnd[idxs.to].lowerValue[0].$.value !== '0' && association.ownedEnd[idxs.to].lowerValue[0].$.value !== undefined) {
     data.isInjectedFieldInToRequired = true;
   }
   return data;
 }
 
-function getAssociationType(association) {
-  if (association.ownedEnd[1].upperValue[0].$.value === '*'
-      && association.ownedEnd[0].upperValue[0].$.value === '*') {
+function getAssociationType(association, idxs) {
+  if (association.ownedEnd[idxs.to].upperValue[0].$.value === '*'
+      && association.ownedEnd[idxs.from].upperValue[0].$.value === '*') {
     return cardinalities.MANY_TO_MANY;
-  } else if (association.ownedEnd[1].upperValue[0].$.value === '*'
-      && association.ownedEnd[0].upperValue[0].$.value !== '*') {
+  } else if (association.ownedEnd[idxs.to].upperValue[0].$.value === '*'
+      && association.ownedEnd[idxs.from].upperValue[0].$.value !== '*') {
     return cardinalities.ONE_TO_MANY;
-  } else if (association.ownedEnd[1].upperValue[0].$.value !== '*'
-      && association.ownedEnd[0].upperValue[0].$.value === '*') {
+  } else if (association.ownedEnd[idxs.to].upperValue[0].$.value !== '*'
+      && association.ownedEnd[idxs.from].upperValue[0].$.value === '*') {
     return cardinalities.MANY_TO_ONE;
   }
   return cardinalities.ONE_TO_ONE;


### PR DESCRIPTION
Changes proposed in this Pull Request:
  - fix memberEnd usage because we cannot change the order of element in xml with the UI, but we can change the member end attribute. So we must use this information. 



