### PR TITLE
Prevent User object from being generated

### DIFF
--- a/jhipster-uml.js
+++ b/jhipster-uml.js
@@ -10,5 +10,7 @@ try {
   console.error(`${chalk.red('Error message:\n\t')}${error.message}`);
   if (error.stack) {
     console.error(`${chalk.red('Stack trace:\n')}${error.stack}`);
+  } else if (error.prototype && error.prototype.stack) {
+    console.error(`${chalk.red('Stack trace:\n')}${error.prototype.stack}`);
   }
 }

--- a/lib/entitiescreator.js
+++ b/lib/entitiescreator.js
@@ -160,7 +160,7 @@ function fillEntities() {
   }
   for (let entity in entitiesToSuppress) {
     if (entitiesToSuppress.hasOwnProperty(entity)) {
-      delete entities[entity];
+      delete entities[entitiesToSuppress[entity]];
     }
   }
 }

--- a/lib/jhipsteruml.js
+++ b/lib/jhipsteruml.js
@@ -115,7 +115,7 @@ function filterOutUnchangedEntities(entities, parsedData) {
     const currEntity = onDiskEntities[name];
     const newEntity = entities[entityIdsByName[name]];
     if (!newEntity) {
-        // if the entitie is not in entities, we don't want it generated at all
+        // if the entity is not in entities, we don't want it generated at all
         return false;
     }
     if (!currEntity) {

--- a/lib/jhipsteruml.js
+++ b/lib/jhipsteruml.js
@@ -93,7 +93,7 @@ if (isJumlFilePresent()) {
 }
 
 exportToJSON(entities, values(entityIdsByName), parsedData, entityNamesToGenerate);
-generateEntities(values(entityIdsByName), parsedData.classes, entityNamesToGenerate, options);
+generateEntities(Object.keys(entities), parsedData.classes, entityNamesToGenerate, options);
 
 function initParserFactoryArgs() {
   const parserFactoryArgs = {
@@ -114,6 +114,10 @@ function filterOutUnchangedEntities(entities, parsedData) {
   return parsedData.classNames.filter(function (name) {
     const currEntity = onDiskEntities[name];
     const newEntity = entities[entityIdsByName[name]];
+    if (!newEntity) {
+        // if the entitie is not in entities, we don't want it generated at all
+        return false;
+    }
     if (!currEntity) {
       return true;
     }


### PR DESCRIPTION
Fixes #248  .

Changes proposed in this Pull Request:
  - Don't let the User class be populated in the entities[] array


